### PR TITLE
Remove compass-mixins and support koala-framework 5.x

### DIFF
--- a/TextImageTeaser/Kwc/Teaser/Component.php
+++ b/TextImageTeaser/Kwc/Teaser/Component.php
@@ -1,16 +1,16 @@
 <?php
 class TextImageTeaser_Kwc_Teaser_Component extends Kwc_Abstract_Composite_Component
 {
-    public static function getSettings()
+    public static function getSettings($param = null)
     {
-        $ret = parent::getSettings();
+        $ret = parent::getSettings($param);
         $ret['componentName'] = trlKwfStatic('Teaser with Image');
         $ret['generators']['child']['component']['image'] = 'TextImageTeaser_Kwc_Teaser_Image_Component';
         $ret['generators']['child']['component']['text'] = 'Kwc_Basic_Text_Component';
         $ret['generators']['child']['component']['link'] = 'Kwc_Basic_LinkTag_Component';
         $ret['extConfig'] = 'TextImageTeaser_Kwc_Teaser_ExtConfig';
         $ret['ownModel'] = 'TextImageTeaser_Kwc_Teaser_Model';
-        $ret['cssClass'] = 'webStandard';
+        $ret['rootElementClass'] = 'kwfUp-webStandard';
 
         $ret['colors'] = array(
             'none' => trlKwfStatic('None'),
@@ -20,9 +20,9 @@ class TextImageTeaser_Kwc_Teaser_Component extends Kwc_Abstract_Composite_Compon
         return $ret;
     }
 
-    public function getTemplateVars()
+    public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer)
     {
-        $ret = parent::getTemplateVars();
+        $ret = parent::getTemplateVars($renderer);
         $ret['color'] = $this->getRow()->color;
         return $ret;
     }

--- a/TextImageTeaser/Kwc/Teaser/Component.scss
+++ b/TextImageTeaser/Kwc/Teaser/Component.scss
@@ -1,9 +1,6 @@
-@import "compass/css3/box-sizing";
-@import "compass/css3/transform";
-
 .kwcClass {
     .kwcBem__image {
-        @include transform(translate3d(0,0,0));                                                                         //optimized on hover
+        transform: translate3d(0, 0, 0); //optimized on hover
         position: relative;
     }
 
@@ -20,7 +17,7 @@
     }
 
     .kwcBem__text {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         padding: 12px 15px 10px 15px;
     }
 }

--- a/TextImageTeaser/Kwc/Teaser/Component.scss
+++ b/TextImageTeaser/Kwc/Teaser/Component.scss
@@ -1,8 +1,8 @@
 @import "compass/css3/box-sizing";
 @import "compass/css3/transform";
 
-.cssClass {
-    .image {
+.kwcClass {
+    .kwcBem__image {
         @include transform(translate3d(0,0,0));                                                                         //optimized on hover
         position: relative;
     }
@@ -19,7 +19,7 @@
         background: #e1e1e1;
     }
 
-    .text {
+    .kwcBem__text {
         @include box-sizing(border-box);
         padding: 12px 15px 10px 15px;
     }

--- a/TextImageTeaser/Kwc/Teaser/Component.twig
+++ b/TextImageTeaser/Kwc/Teaser/Component.twig
@@ -1,11 +1,11 @@
-<div class="{{ cssClass }} {{ color }}">
+<div class="{{ rootElementClass }} {{ color }}">
     {% if link.hasContent() %}
     {{ renderer.component(link) }}
     {% endif %}
-    <div class="image">
+    <div class="{{ 'image'|bemClass }}">
         {{ renderer.component(image) }}
     </div>
-    <div class="text">
+    <div class="{{ 'text'|bemClass }}">
         {{ renderer.component(text) }}
     </div>
     {% if link.hasContent() %}

--- a/TextImageTeaser/Kwc/Teaser/Image/Component.php
+++ b/TextImageTeaser/Kwc/Teaser/Image/Component.php
@@ -1,9 +1,9 @@
 <?php
 class TextImageTeaser_Kwc_Teaser_Image_Component extends Kwc_Basic_Image_Component
 {
-    public static function getSettings()
+    public static function getSettings($param = null)
     {
-        $ret = parent::getSettings();
+        $ret = parent::getSettings($param);
         $ret['dimensions'] = array(
             'default'=>array(
                 'text' => trlKwfStatic('full width'),

--- a/TextImageTeaser/Kwc/Teaser/Image/Component.scss
+++ b/TextImageTeaser/Kwc/Teaser/Image/Component.scss
@@ -1,20 +1,15 @@
-@import "compass/css3/transition";
-@import "compass/css3/box-sizing";
-@import "compass/css3/transform";
-@import "compass/css3/opacity";
-
 .kwcClass {
     img {
-        @include transition-property(all);
-        @include transition-duration(0.4s);
-        @include transform(scale(1,1));
+        transition-property: all;
+        transition-duration: 0.4s;
+        transform: scale(1, 1);
     }
 
     .kwcBem__imageCaption {
-        @include box-sizing(border-box);
-        @include opacity(0);
-        @include transition-property(opacity);
-        @include transition-duration(0.2s);
+        box-sizing: border-box;
+        opacity: 0;
+        transition-property: opacity;
+        transition-duration: 0.2s;
         background: rgba(0, 0, 0, 0.5);
         text-transform: uppercase;
         padding: 10px 0 0px 0;
@@ -30,30 +25,30 @@
             text-align: center;
             width: 100%;
             top: 50%;
-            @include transition-property(all);
-            @include transition-duration(0.2s);
-            @include transform(translate3d(0px, 100px, 0px));
+            transition-property: all;
+            transition-duration: 0.2s;
+            transform: translate3d(0, 100px, 0);
         }
     }
 
     &:hover {
         .kwcBem__imageCaption {
             height: 100%;
-            @include transition-property(opacity);
-            @include transition-duration(0.4s);
-            @include opacity(1);
+            transition-property: opacity;
+            transition-duration: 0.4s;
+            opacity: 1;
 
             span {
-                @include transition-property(all);
-                @include transition-duration(0.4s);
-                @include transform(translate3d(0px, 0px, 0px));
+                transition-property: all;
+                transition-duration: 0.4s;
+                transform: translate3d(0, 0, 0);
             }
         }
 
         img {
-            @include transition-property(all);
-            @include transition-duration(0.4s);
-            @include transform(scale(1.03,1.03));
+            transition-property: all;
+            transition-duration: 0.4s;
+            transform: scale(1.03, 1.03);
         }
     }
 }

--- a/TextImageTeaser/Kwc/Teaser/Image/Component.scss
+++ b/TextImageTeaser/Kwc/Teaser/Image/Component.scss
@@ -3,14 +3,14 @@
 @import "compass/css3/transform";
 @import "compass/css3/opacity";
 
-.cssClass {
+.kwcClass {
     img {
         @include transition-property(all);
         @include transition-duration(0.4s);
         @include transform(scale(1,1));
     }
 
-    .imageCaption {
+    .kwcBem__imageCaption {
         @include box-sizing(border-box);
         @include opacity(0);
         @include transition-property(opacity);
@@ -37,7 +37,7 @@
     }
 
     &:hover {
-        .imageCaption {
+        .kwcBem__imageCaption {
             height: 100%;
             @include transition-property(opacity);
             @include transition-duration(0.4s);

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-2-Clause",
     "type": "library",
     "require": {
-        "koala-framework/koala-framework": "4.0"
+        "koala-framework/koala-framework": "~4.1 || ~5.0"
     },
     "require-dev": {
     },

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-2-Clause",
     "type": "library",
     "require": {
-        "koala-framework/koala-framework": "~3.8"
+        "koala-framework/koala-framework": "4.0"
     },
     "require-dev": {
     },

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-2-Clause",
     "type": "library",
     "require": {
-        "koala-framework/koala-framework": ">= 3.8"
+        "koala-framework/koala-framework": "~3.8"
     },
     "require-dev": {
     },


### PR DESCRIPTION
The compass-mixins are no longer required because of the autoprefixer.